### PR TITLE
Add Docker Compose environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:18
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install --omit=dev
+
+COPY tsconfig.json ./
+COPY src ./src
+
+RUN npm run build
+
+CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ The project aims to provide a mobile-friendly dashboard where users can connect 
 5. Configure environment variables for Withings API credentials and database access.
 6. Use `docker compose up` to start the database and application services.
 
+## Docker Compose Setup
+
+The `docker-compose.yml` file defines two services:
+
+- **db** – a PostgreSQL database with default credentials `sleep`/`sleep`.
+- **app** – builds the Node image from this repository and runs the compiled server.
+
+Run `docker compose up` to build the images and launch both services.
+
 Formatting and linting can be run with `npm run format` and `npm run lint`.
 
 This README will be expanded with setup and usage instructions as the project evolves.

--- a/TASKS.md
+++ b/TASKS.md
@@ -7,9 +7,9 @@ This document lists the tasks required to implement the Sleep Dashboard project 
    - [x] Configure ESLint, Prettier, and basic formatting scripts.
    - [x] Create a `src/` directory for server and client code.
 
-2. **Docker Compose Environment**
-   - Write a `docker-compose.yml` file with services for Postgres and the Node app.
-   - Provide a Dockerfile for the Node service.
+2. **Docker Compose Environment** (completed)
+   - [x] Write a `docker-compose.yml` file with services for Postgres and the Node app.
+   - [x] Provide a Dockerfile for the Node service.
 
 3. **Database Schema**
    - Define Prisma models for `User` and `SleepRecord`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: sleep
+      POSTGRES_PASSWORD: sleep
+      POSTGRES_DB: sleep
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    ports:
+      - '5432:5432'
+  app:
+    build: .
+    ports:
+      - '3000:3000'
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: postgres://sleep:sleep@db:5432/sleep
+volumes:
+  db_data:


### PR DESCRIPTION
## Summary
- add Dockerfile for building the Node service
- add docker-compose.yml with Node and Postgres services
- describe Compose setup in README
- mark Docker Compose task as completed

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_68847c0d2d60832ba1776f9c8c764974